### PR TITLE
add link to lab manual on web page resources

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,6 +47,8 @@
       <li><a href="onboard.html">ONBOARDING </a></li>
       
       <li><a href="https://github.com/KellerLab-Dartmouth">GITHUB</a></li>
+
+      <li><a href="https://keller-lab.github.io/web-manual">LAB MANUAL</a></li>
       
       </ul>
       


### PR DESCRIPTION
Added a list element to the RESOURCE tab of the webpage so people can see the lab manual more easily. I tested that it works on a local port. Checkout the changes on the new web-manual branch (just one change) and feel free to merge it in if you like how it looks.